### PR TITLE
Edits invalid package name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .idea/
+*.swp
+node_modules

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "Feedhenry Drag & Drop Apps Integration Client",
+  "name": "fh-dnd-integration-client",
   "private": true,
   "version": "0.1.0",
   "dependencies": {},


### PR DESCRIPTION
- package name was not valid, `npm install` wouldn't work.